### PR TITLE
Add black and white map background to landing page

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,8 @@
     "sonner": "^1.5.0",
     "tailwind-merge": "^2.5.2",
     "tailwindcss-animate": "^1.0.7",
+    "leaflet": "^1.9.4",
+    "react-leaflet": "^4.2.1",
     "uuid": "^11.1.0",
     "vaul": "^0.9.3",
     "zod": "^3.23.8"

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@/components/ui/button';
+import { MapContainer, TileLayer } from 'react-leaflet';
 
 interface LandingPageProps {
   onRequestClick: () => void;
@@ -6,20 +7,36 @@ interface LandingPageProps {
 
 const LandingPage = ({ onRequestClick }: LandingPageProps) => {
   return (
-    <div className="min-h-screen bg-black flex flex-col items-center justify-center">
-      <h1 className="text-white text-8xl md:text-9xl font-bold mb-4 tracking-wider">
-        SHADOW
-      </h1>
-      <p className="text-white text-2xl md:text-3xl font-light mb-8 tracking-wide">
-        The Security Marketplace
-      </p>
-      <Button 
-        onClick={onRequestClick}
-        size="lg"
-        className="bg-white text-black hover:bg-gray-200 px-8 py-4 text-xl font-semibold"
+    <div className="relative min-h-screen">
+      <MapContainer
+        center={[20, 0]}
+        zoom={2}
+        scrollWheelZoom={false}
+        doubleClickZoom={false}
+        dragging={false}
+        zoomControl={false}
+        touchZoom={false}
+        className="absolute inset-0 z-0 grayscale"
+        attributionControl={false}
       >
-        REQUEST
-      </Button>
+        <TileLayer url="https://tiles.wmflabs.org/bw-mapnik/{z}/{x}/{y}.png" />
+      </MapContainer>
+
+      <div className="absolute inset-0 z-10 flex flex-col items-center justify-center">
+        <h1 className="text-white text-8xl md:text-9xl font-bold mb-4 tracking-wider">
+          SHADOW
+        </h1>
+        <p className="text-white text-2xl md:text-3xl font-light mb-8 tracking-wide">
+          The Security Marketplace
+        </p>
+        <Button
+          onClick={onRequestClick}
+          size="lg"
+          className="bg-white text-black hover:bg-gray-200 px-8 py-4 text-xl font-semibold"
+        >
+          REQUEST
+        </Button>
+      </div>
     </div>
   );
 };

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,6 @@
 
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap');
+@import url('leaflet/dist/leaflet.css');
 
 @tailwind base;
 @tailwind components;


### PR DESCRIPTION
## Summary
- install `leaflet` and `react-leaflet` dependencies
- import Leaflet CSS globally
- display a non‑interactive black & white world map as the landing page background

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686110f94d60832a9247538253a03976