### PR TITLE
Add interactive landing page map

### DIFF
--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -11,15 +11,11 @@ const LandingPage = ({ onRequestClick }: LandingPageProps) => {
       <MapContainer
         center={[20, 0]}
         zoom={2}
-        scrollWheelZoom={false}
-        doubleClickZoom={false}
-        dragging={false}
-        zoomControl={false}
-        touchZoom={false}
-        className="absolute inset-0 z-0 grayscale"
+        scrollWheelZoom
+        className="absolute inset-0 z-0"
         attributionControl={false}
       >
-        <TileLayer url="https://tiles.wmflabs.org/bw-mapnik/{z}/{x}/{y}.png" />
+        <TileLayer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png" />
       </MapContainer>
 
       <div className="absolute inset-0 z-10 flex flex-col items-center justify-center">


### PR DESCRIPTION
## Summary
- update landing page map to use OpenStreetMap tiles
- enable zoom and panning for a live, interactive background

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6861d7930cb8832ab1af16d4dac42fb6