### PR TITLE
Add page to show available security providers

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { ThemeProvider } from "@/components/theme-provider";
 import Index from "./pages/Index";
 import NotFound from "./pages/NotFound";
+import AvailableProviders from "./pages/AvailableProviders";
 
 const queryClient = new QueryClient();
 
@@ -19,6 +20,7 @@ const App = () => (
         <BrowserRouter>
           <Routes>
             <Route path="/" element={<Index />} />
+            <Route path="/providers" element={<AvailableProviders />} />
             <Route path="*" element={<NotFound />} />
           </Routes>
         </BrowserRouter>

--- a/src/components/ProviderCard.tsx
+++ b/src/components/ProviderCard.tsx
@@ -13,7 +13,11 @@ interface ProviderCardProps {
 
 export const ProviderCard = ({ provider, onHire, showHireButton = true }: ProviderCardProps) => {
   return (
-    <Card className="hover:shadow-lg transition-shadow">
+    <Card
+      className={`hover:shadow-lg transition-shadow ${
+        provider.available ? 'border-green-500' : 'opacity-70'
+      }`}
+    >
       <CardHeader>
         <div className="flex items-center gap-3">
           <Avatar className="w-12 h-12">
@@ -32,6 +36,11 @@ export const ProviderCard = ({ provider, onHire, showHireButton = true }: Provid
               {provider.rating} • {provider.experience}
             </div>
           </div>
+          {provider.available && (
+            <Badge variant="success" size="sm" className="ml-auto">
+              Available
+            </Badge>
+          )}
         </div>
       </CardHeader>
       <CardContent>
@@ -47,12 +56,13 @@ export const ProviderCard = ({ provider, onHire, showHireButton = true }: Provid
           ))}
         </div>
         {showHireButton && (
-          <Button 
-            onClick={() => onHire?.(provider.id)} 
+          <Button
+            onClick={() => provider.available && onHire?.(provider.id)}
             className="w-full"
             variant="outline"
+            disabled={!provider.available}
           >
-            Contact Provider
+            {provider.available ? 'Contact Provider' : 'Unavailable'}
           </Button>
         )}
       </CardContent>

--- a/src/data/mockData.ts
+++ b/src/data/mockData.ts
@@ -45,7 +45,8 @@ export const mockProviders: Provider[] = [
     specialties: ['Executive Protection', 'Event Security', 'Threat Assessment'],
     hourlyRate: '$120',
     verified: true,
-    avatar: '/placeholder.svg'
+    avatar: '/placeholder.svg',
+    available: true
   },
   {
     id: '2',
@@ -55,7 +56,8 @@ export const mockProviders: Provider[] = [
     specialties: ['Corporate Security', 'Surveillance', 'Risk Management'],
     hourlyRate: '$85',
     verified: true,
-    avatar: '/placeholder.svg'
+    avatar: '/placeholder.svg',
+    available: false
   },
   {
     id: '3',
@@ -65,6 +67,7 @@ export const mockProviders: Provider[] = [
     specialties: ['Personal Protection', 'Armed Security', 'Investigation'],
     hourlyRate: '$95',
     verified: true,
-    avatar: '/placeholder.svg'
+    avatar: '/placeholder.svg',
+    available: true
   }
 ];

--- a/src/pages/AvailableProviders.tsx
+++ b/src/pages/AvailableProviders.tsx
@@ -1,0 +1,31 @@
+import React, { useState } from 'react';
+import { AppProvider } from '@/contexts/AppContext';
+import { ProviderCard } from '@/components/ProviderCard';
+import { Header } from '@/components/Header';
+import { mockProviders } from '@/data/mockData';
+
+const AvailableProviders: React.FC = () => {
+  const [searchTerm, setSearchTerm] = useState('');
+
+  const filteredProviders = mockProviders
+    .filter(p => p.available)
+    .filter(p =>
+      p.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
+      p.specialties.some(s => s.toLowerCase().includes(searchTerm.toLowerCase()))
+    );
+
+  return (
+    <AppProvider>
+      <div className="min-h-screen bg-gray-50">
+        <Header onPostJob={() => {}} searchTerm={searchTerm} onSearchChange={setSearchTerm} />
+        <div className="container mx-auto px-4 py-8 grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+          {filteredProviders.map(provider => (
+            <ProviderCard key={provider.id} provider={provider} />
+          ))}
+        </div>
+      </div>
+    </AppProvider>
+  );
+};
+
+export default AvailableProviders;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -19,6 +19,7 @@ export interface Provider {
   hourlyRate: string;
   verified: boolean;
   avatar: string;
+  available?: boolean;
 }
 
 export interface Application {


### PR DESCRIPTION
## Summary
- mark providers with an `available` flag in types and mock data
- highlight available status in `ProviderCard`
- create an `AvailableProviders` page listing active providers
- add `/providers` route to access the new page

## Testing
- `npm run build` *(fails: vite not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_6861da1f4114832ab375ce856abb6b84