### PR TITLE
Add landing page as default with sign-up link

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,7 +20,8 @@ const App = () => (
         <Sonner />
         <BrowserRouter>
           <Routes>
-            <Route path="/" element={<SignUp />} />
+            <Route path="/" element={<Index />} />
+            <Route path="/signup" element={<SignUp />} />
             <Route path="/app" element={<Index />} />
             <Route path="/providers" element={<AvailableProviders />} />
             <Route path="*" element={<NotFound />} />

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -1,5 +1,6 @@
 import { Button } from '@/components/ui/button';
 import { MapContainer, TileLayer } from 'react-leaflet';
+import { Link } from 'react-router-dom';
 
 interface LandingPageProps {
   onRequestClick: () => void;
@@ -17,6 +18,10 @@ const LandingPage = ({ onRequestClick }: LandingPageProps) => {
       >
         <TileLayer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png" />
       </MapContainer>
+
+      <Link to="/signup" className="absolute top-4 right-4 z-20 text-white font-semibold">
+        Sign Up
+      </Link>
 
       <div className="absolute inset-0 z-10 flex flex-col items-center justify-center">
         <h1 className="text-white text-8xl md:text-9xl font-bold mb-4 tracking-wider">


### PR DESCRIPTION
## Summary
- route `/` to the landing page instead of SignUp
- move the SignUp page to `/signup`
- add a sign-up link to the top right corner of the landing page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6861df2c06e8832a9eda2f8f56fa953e